### PR TITLE
22 nezha fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,34 +32,15 @@ to facilitate experimentation and native building.
 
 ## Building
 
-In order to build this kernel snap some small changes must be made which make
-building this snap different from others. Once [this](https://github.com/canonical/craft-archives/issues/104) 
-issue has been resolved, the below interventions should not be required. Until
-then, here are instructions for building this snap, assuming amd64 build host:
+In order to build this kernel snap, build and install the above snapcraft fork.
+Then, assuming amd64 build host:
 
 ```sh
-  lxc launch ubuntu:22.04 kernel-snaps
-  lxc file push path/to/modified/snapcraft/snapcraft*.snap kernel-snaps/root/
-  lxc shell kernel-snaps
-
-  sed -i 's/deb h/deb [arch=amd64] h/' /etc/apt/sources.list
-
-  { echo 'Types: deb deb-src'; \
-    echo 'URIs: http://ports.ubuntu.com/ubuntu-ports'; \
-    echo 'Suites: jammy jammy-updates jammy-backports'; \
-    echo 'Components: main universe restricted multiverse'; \
-    echo 'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg'; \
-    echo 'Architectures: riscv64'; } >> /etc/apt/sources.list.d/ubuntu.sources
-
-  apt update
-
-  snap install --dangerous --classic /root/snapcraft*.snap
-
   git clone \
     --depth 1 \
     --branch 22-riscv64-nezha \
     https://github.com/canonical/iot-field-kernel-snap \
     22-riscv64-nezha-kernel && cd 22-riscv64-nezha-kernel
 
-  snapcraft --destructive-mode --enable-experimental-plugins
+  snapcraft --enable-experimental-plugins
 ```

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,7 +80,6 @@ parts:
     build-packages:
       - gcc-${CRAFT_ARCH_TRIPLET_BUILD_FOR}
     stage-packages:
-      - licheerv-rtl8723ds-dkms:${CRAFT_ARCH_BUILD_FOR}
       - linux-firmware:${CRAFT_ARCH_BUILD_FOR}
       - wireless-regdb
     override-build: |
@@ -97,39 +96,13 @@ parts:
       install -Dm644 "${CRAFT_PART_SRC}/LICENSES/exceptions/Linux-syscall-note" \
                      "${CRAFT_PART_INSTALL}/LICENSE.exception"
 
-      # Create directories that are canonically expected to exist
-      ln -sf ../../../src   "${CRAFT_PART_INSTALL}/lib/modules/${kver}/source"
-      ln -sf ../../../build "${CRAFT_PART_INSTALL}/lib/modules/${kver}/build"
-
-      # Build the rtl8723ds kernel module
-      cd "${CRAFT_PART_INSTALL}/usr/src/licheerv-rtl8723ds-"*
-
-      make -j${CRAFT_PARALLEL_BUILD_COUNT} \
-        ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- \
-        KSRC="${CRAFT_PART_INSTALL}/lib/modules/${kver}/build" \
-        modules
-
-      # First, regenerate module dependency list
-      install -Dm644 8723ds.ko \
-        "${CRAFT_PART_INSTALL}/lib/modules/${kver}/kernel/drivers/net/wireless/8723ds.ko"
-
-      depmod -a -b "${CRAFT_PART_INSTALL}/" "${kver}"
-
-      # Then, move the module into the component
-      mkdir -p "${CRAFT_COMPONENT_WLAN_PRIME}/lib/modules/${kver}/kernel/drivers/net/wireless"
-
-      mv -f "${CRAFT_PART_INSTALL}/modules/${kver}/kernel/drivers/net/wireless/8723ds.ko" \
-        "${CRAFT_COMPONENT_WLAN_PRIME}/lib/modules/${kver}/kernel/drivers/net/wireless/8723ds.ko"
-
-      mv -f "${CRAFT_PART_INSTALL}/firmware/rtl_bt" "${CRAFT_PART_INSTALL}/rtl_bt"
-
       "${CRAFT_STAGE}/trim-firmware" "${CRAFT_PART_INSTALL}"
     organize:
-       LICENSE: licenses/kernel.license
-       LICENSE.exception: licenses/kernel.license-exception
-       dtbs/allwinner: dtbs/
-       rtl_bt/rtl8723d_config.bin: (component/wlan)/firmware/rtl_bt/rtl8723d_config.bin
-       rtl_bt/rtl8723d_fw.bin: (component/wlan)/firmware/rtl_bt/rtl8723d_fw.bin
+      LICENSE: licenses/kernel.license
+      LICENSE.exception: licenses/kernel.license-exception
+      dtbs/allwinner: dtbs/
+      lib/firmware/rtl_bt/rtl8723d_fw.bin: (component/wlan)/firmware/rtl_bt/rtl8723d_fw.bin
+      lib/firmware/rtl_bt/rtl8723d_config.bin: (component/wlan)/firmware/rtl_bt/rtl8723d_config.bin
     stage:
       - System.map-*
       - config-*
@@ -145,6 +118,34 @@ parts:
       - modules/
     prime:
       - -kernel.img
+
+  wlan:
+    after: [kernel]
+    plugin: nil
+    source: https://git.launchpad.net/ubuntu/+source/licheerv-rtl8723ds-dkms
+    source-type: git
+    source-depth: 1
+    source-branch: applied/ubuntu/jammy-updates
+    build-packages: [build-essential, dkms]
+    override-build: |
+      kver="$(basename "${CRAFT_STAGE}/lib/modules/"*)"
+      driver_path="lib/modules/${kver}/kernel/drivers/net/wireless"
+
+      make -j${CRAFT_PARALLEL_BUILD_COUNT} \
+        ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- \
+        KSRC="${CRAFT_PART_BUILD}/../../kernel/build" \
+        modules
+
+      install -Dm644 8723ds.ko "${CRAFT_COMPONENT_WLAN_PRIME}/${driver_path}/8723ds.ko"
+    override-stage: |
+      kver="$(basename "${CRAFT_STAGE}/lib/modules/"*)"
+
+      craftctl default
+
+      # Regenerate module dependency list
+      depmod -a -b "${CRAFT_STAGE}/" "${kver}"
+    stage:
+      - -8723ds.ko
 
   # Provide the initrd for Ubuntu Core.
   # The initrd includes important things such as snap-bootstrap which

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,15 +35,13 @@ architectures:
   - build-on:  [amd64]
     build-for: [riscv64]
 
-# In an ideal universe, this would be all we would have to do. Unfortunately,
-# the workaround in the README is required for core22 builds.
-# package-repositories:
-#   - type: apt
-#     components: [main, universe]
-#     architectures: [riscv64]
-#     suites: [jammy, jammy-updates]
-#     key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
-#     url: http://ports.ubuntu.com/ubuntu-ports
+package-repositories:
+  - type: apt
+    components: [main, universe]
+    architectures: [riscv64]
+    suites: [jammy, jammy-updates]
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
+    url: http://ports.ubuntu.com/ubuntu-ports
 
 parts:
   # Trimming any firmware we know a priori to not be needed by the target device


### PR DESCRIPTION
Update build to reflect new simplicity offered by more recent versions of snapcraft. Basically, we don't have to manually intervene to fix package sources for apt anymore :)

Factor out the 8723ds driver from being crudely built as a DKMS package to instead being its own standalone part, shipped as a component. This keeps things a little more "straightforward", until DKMS is potentially supported more natively in the kernel plugin.