### PR TITLE
24-riscv64-nezha: snapcraft.yaml: generecize component version string

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -605,8 +605,9 @@ parts:
 components:
   wlan:
     type: kernel-modules
-    # It would be nice if the component version could be set by the kernel part
-    version: 6.8.0-53.55-generic
+    # It would be nice if the component version could be set by the kernel part.
+    # This version string may (probably will) fall out of sync.
+    version: 6.8.0-generic
     summary: The Realtek 8723ds WiFi module and firmware
     description: |
       The 8723ds Realtek WiFi kernel module used by the Sipeed LicheeRV. This


### PR DESCRIPTION
This is planned to be programmatically definable in the future. For now, lock the version against the X.Y version of the kernel, not the ABI version; components are locked to the snap revision anyways, and considering how this driver is built we're guaranteed ABI compatibility.