### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/snap-build.yaml
+++ b/.github/workflows/snap-build.yaml
@@ -61,7 +61,7 @@ jobs:
         run: |
           cd nezha
           sed -i "s/name: /name: ${{ secrets.STORE_PREFIX }}-/" snap/snapcraft.yaml
-          sudo snapcraft --enable-experimental-plugins
+          sudo snapcraft --enable-experimental-plugins --destructive-mode
       - name: Upload 22/nezha
         uses: snapcore/action-publish@v1
         env:
@@ -94,7 +94,7 @@ jobs:
         run: |
           cd odroid-hc4
           sed -i "s/name: /name: ${{ secrets.STORE_PREFIX }}-/" snap/snapcraft.yaml
-          sudo snapcraft --enable-experimental-plugins
+          sudo snapcraft --enable-experimental-plugins --destructive-mode
       ## Not being maintained...
       - name: Upload 22/odroid-hc4
         uses: snapcore/action-publish@v1
@@ -128,7 +128,7 @@ jobs:
         run: |
           cd orangepi-5plus
           sed -i "s/name: /name: ${{ secrets.STORE_PREFIX }}-/" snap/snapcraft.yaml
-          sudo snapcraft --enable-experimental-plugins
+          sudo snapcraft --enable-experimental-plugins --destructive-mode
       ## Not being maintained...
       - name: Upload latest/edge
         uses: snapcore/action-publish@v1
@@ -162,7 +162,7 @@ jobs:
         run: |
           cd polarfire-icicle
           sed -i "s/name: /name: ${{ secrets.STORE_PREFIX }}-/" snap/snapcraft.yaml
-          sudo snapcraft --enable-experimental-plugins
+          sudo snapcraft --enable-experimental-plugins --destructive-mode
       ## Not being maintained...
       - name: Upload 22/polarfire-icicle
         uses: snapcore/action-publish@v1
@@ -199,7 +199,7 @@ jobs:
         run: |
           cd nezha
           sed -i "s/name: /name: ${{ secrets.STORE_PREFIX }}-/" snap/snapcraft.yaml
-          sudo snapcraft
+          sudo snapcraft --destructive-mode
       - name: Upload 24/nezha
         uses: snapcore/action-publish@v1
         env:
@@ -232,7 +232,7 @@ jobs:
         run: |
           cd visionfive2
           sed -i "s/name: /name: ${{ secrets.STORE_PREFIX }}-/" snap/snapcraft.yaml
-          sudo snapcraft
+          sudo snapcraft --destructive-mode
       - name: Upload 24/visionfive2
         uses: snapcore/action-publish@v1
         env:

--- a/.github/workflows/snap-build.yaml
+++ b/.github/workflows/snap-build.yaml
@@ -49,6 +49,7 @@ jobs:
           wget https://github.com/canonical/iot-field-kernel-snap/releases/download/temp/snapcraft_8.10.0.post45_amd64.snap
 
           sudo snap install --dangerous --classic snapcraft*.snap
+          sudo apt install qemu-user-static
 
           rm -f snapcraft*.snap
       - name: Build 22/nezha
@@ -82,6 +83,7 @@ jobs:
           wget https://github.com/canonical/iot-field-kernel-snap/releases/download/temp/snapcraft_8.10.0.post45_amd64.snap
 
           sudo snap install --dangerous --classic snapcraft*.snap
+          sudo apt install qemu-user-static
 
           rm -f snapcraft*.snap
       - name: Build 22/odroid-hc4
@@ -116,6 +118,7 @@ jobs:
           wget https://github.com/canonical/iot-field-kernel-snap/releases/download/temp/snapcraft_8.10.0.post45_amd64.snap
 
           sudo snap install --dangerous --classic snapcraft*.snap
+          sudo apt install qemu-user-static
 
           rm -f snapcraft*.snap
       - name: Build 22/orangepi-5plus
@@ -150,6 +153,7 @@ jobs:
           wget https://github.com/canonical/iot-field-kernel-snap/releases/download/temp/snapcraft_8.10.0.post45_amd64.snap
 
           sudo snap install --dangerous --classic snapcraft*.snap
+          sudo apt install qemu-user-static
 
           rm -f snapcraft*.snap
       - name: Build 22/polarfire-icicle
@@ -187,6 +191,7 @@ jobs:
           wget https://github.com/canonical/iot-field-kernel-snap/releases/download/temp/snapcraft_8.10.0.post45_amd64.snap
 
           sudo snap install --dangerous --classic snapcraft*.snap
+          sudo apt install qemu-user-static
 
           rm -f snapcraft*.snap
       - name: Build 24/nezha
@@ -220,6 +225,7 @@ jobs:
           wget https://github.com/canonical/iot-field-kernel-snap/releases/download/temp/snapcraft_8.10.0.post45_amd64.snap
 
           sudo snap install --dangerous --classic snapcraft*.snap
+          sudo apt install qemu-user-static
 
           rm -f snapcraft*.snap
       - name: Build 24/visionfive2

--- a/.github/workflows/snap-build.yaml
+++ b/.github/workflows/snap-build.yaml
@@ -19,19 +19,39 @@ on:
 
 # Convention:
 # jobs:
-#   build_<branch name>_<snapcraft track>:
-#     name: <snapcraft track> job for <branch> snap
-#     runs-on: ubuntu-<base>
+#   <platform>_<core release>:
+#     name: <snapcraft release> job for <core release>/<platform>
+#     runs-on: ubuntu-<core release>.04
 #     steps:
-#       - name: Checkout <branch>
-#         uses: actions/checkout@v4
+#       - uses: actions/checkout@v4
 #         with:
-#           ref: <branch>
-#       - name: Test build of <branch> snap with snapcraft <channel>
-#         uses: snapcore/action-build@v1
+#           ref: <core release>
+#       - name: Setup build environment
+#         run: |
+#           # Temporary, until kernel+initrd plugins are merged
+#           wget https://github.com/canonical/iot-field-kernel-snap/releases/download/temp/snapcraft_8.10.0.post45_amd64.snap
+#           sudo snap install --dangerous --classic snapcraft*.snap
+#           rm -f snapcraft*.snap
+#           # For building the initrd
+#           sudo apt install qemu-user-static
+#         # Temporary, until kernel+initrd plugins are merged
+#       - name: Build <core release>/<platform>
+#         id: build
+#         env:
+#           SNAPCRAFT_UA_TOKEN: ${{ secrets.UA_TOKEN }}
+#           SNAPCRAFT_BUILD_INFO: 1
+#           SNAPCRAFT_VERBOSITY_LEVEL: verbose
+#         run: |
+#           cd <platform>
+#           sed -i "s/name: /name: ${{ secrets.STORE_PREFIX }}-/" snap/snapcraft.yaml
+#           sudo snapcraft --enable-experimental-plugins --destructive-mode
+#       - name: Upload <core release>/<platform>
+#         uses: snapcore/action-publish@v1
+#         env:
+#           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
 #         with:
-#           snapcraft-channel: <track>/<risk>/<branch>
-#           snapcraft-args: --verbosity=verbose
+#           snap: ${{ steps.build.outputs.snap }}
+#           release: <track>/edge
 
 ##########
 ### 22 ###

--- a/.github/workflows/snap-build.yaml
+++ b/.github/workflows/snap-build.yaml
@@ -138,8 +138,8 @@ jobs:
           snap: ${{ steps.build.outputs.snap }}
           release: latest/edge
 
-  polarfire_22:
-    name: latest/edge job for 22/polarfire
+  polarfire-icicle_22:
+    name: latest/edge job for 22/polarfire-icicle
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -152,7 +152,7 @@ jobs:
           sudo snap install --dangerous --classic snapcraft*.snap
 
           rm -f snapcraft*.snap
-      - name: Build 22/polarfire
+      - name: Build 22/polarfire-icicle
         id: build
         env:
           SNAPCRAFT_UA_TOKEN: ${{ secrets.UA_TOKEN }}
@@ -164,7 +164,7 @@ jobs:
           sed -i "s/name: /name: ${{ secrets.STORE_PREFIX }}-/" snap/snapcraft.yaml
           sudo snapcraft --enable-experimental-plugins
       ## Not being maintained...
-      - name: Upload 22/polarfire
+      - name: Upload 22/polarfire-icicle
         uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}


### PR DESCRIPTION
Workflow has been revised to work with latest kernel and initrd plugins and the restructuring.

These workflows will fail for a variety of reasons, this will be worked on. Probably in the the future we disable the workflows and just build on Launchpad, we'll see.